### PR TITLE
Fix Go imports

### DIFF
--- a/xdr/bench_test.go
+++ b/xdr/bench_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/davecgh/go-xdr/xdr"
+	"github.com/stellar/go-xdr/xdr"
 )
 
 func BenchmarkUnmarshal(b *testing.B) {

--- a/xdr/example_test.go
+++ b/xdr/example_test.go
@@ -19,7 +19,7 @@ package xdr_test
 import (
 	"fmt"
 
-	"github.com/davecgh/go-xdr/xdr"
+	"github.com/stellar/go-xdr/xdr"
 )
 
 // This example demonstrates how to use Marshal to automatically XDR encode

--- a/xdr2/bench_test.go
+++ b/xdr2/bench_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/davecgh/go-xdr/xdr2"
+	"github.com/stellar/go-xdr/xdr2"
 )
 
 // BenchmarkUnmarshal benchmarks the Unmarshal function by using a dummy

--- a/xdr2/decode_test.go
+++ b/xdr2/decode_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/davecgh/go-xdr/xdr2"
+	. "github.com/stellar/go-xdr/xdr2"
 )
 
 // subTest is used to allow testing of the Unmarshal function into struct fields

--- a/xdr2/encode_test.go
+++ b/xdr2/encode_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/davecgh/go-xdr/xdr2"
+	. "github.com/stellar/go-xdr/xdr2"
 )
 
 // testExpectedMRet is a convenience method to test an expected number of bytes

--- a/xdr2/error_test.go
+++ b/xdr2/error_test.go
@@ -19,7 +19,7 @@ package xdr_test
 import (
 	"testing"
 
-	. "github.com/davecgh/go-xdr/xdr2"
+	. "github.com/stellar/go-xdr/xdr2"
 )
 
 // TestErrorCodeStringer tests the stringized output for the ErrorCode type.

--- a/xdr2/example_test.go
+++ b/xdr2/example_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/davecgh/go-xdr/xdr2"
+	"github.com/stellar/go-xdr/xdr2"
 )
 
 // This example demonstrates how to use Marshal to automatically XDR encode

--- a/xdr3/bench_test.go
+++ b/xdr3/bench_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/nullstyle/go-xdr/xdr3"
+	"github.com/stellar/go-xdr/xdr3"
 )
 
 // BenchmarkUnmarshal benchmarks the Unmarshal function by using a dummy

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/nullstyle/go-xdr/xdr3"
+	. "github.com/stellar/go-xdr/xdr3"
 )
 
 // subTest is used to allow testing of the Unmarshal function into struct fields

--- a/xdr3/encode_test.go
+++ b/xdr3/encode_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/nullstyle/go-xdr/xdr3"
+	. "github.com/stellar/go-xdr/xdr3"
 )
 
 // testExpectedMRet is a convenience method to test an expected number of bytes

--- a/xdr3/error_test.go
+++ b/xdr3/error_test.go
@@ -19,7 +19,7 @@ package xdr_test
 import (
 	"testing"
 
-	. "github.com/nullstyle/go-xdr/xdr3"
+	. "github.com/stellar/go-xdr/xdr3"
 )
 
 // TestErrorCodeStringer tests the stringized output for the ErrorCode type.

--- a/xdr3/example_test.go
+++ b/xdr3/example_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/nullstyle/go-xdr/xdr3"
+	"github.com/stellar/go-xdr/xdr3"
 )
 
 // This example demonstrates how to use Marshal to automatically XDR encode


### PR DESCRIPTION
Those imports confuse `go mod tidy` leading to extra packages in `stellar/go` dependencies (see https://github.com/stellar/go/blob/master/go.mod#L52 vs. https://github.com/stellar/go/blob/master/go.mod#L72).

/cc @bartekn 