### PR TITLE
Fix markdown mistakes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # go-xdr
 
-[![Build Status](https://travis-ci.org/stellar/go-xdr.png?branch=master)]
-(https://travis-ci.org/stellar/go-xdr) [![Coverage Status]
-[![GoDoc](https://godoc.org/github.com/stellar/go-xdr/xdr3?status.png)]
-(http://godoc.org/github.com/stellar/go-xdr/xdr2)
+[![Build Status](https://travis-ci.org/stellar/go-xdr.png?branch=master)](https://travis-ci.org/stellar/go-xdr)
+[![GoDoc](https://godoc.org/github.com/stellar/go-xdr/xdr3?status.png)](http://godoc.org/github.com/stellar/go-xdr/xdr2)
 
 Go-xdr implements the data representation portion of the External Data
 Representation (XDR) standard protocol as specified in RFC 4506 (obsoletes RFC
@@ -24,4 +22,4 @@ changes to pointer decoding, ability to constrain sizes and some fixes.
 
 Licensed under the ISC License.
 
-original go-xdr: https://github.com/davecgh/go-xdr
+[original go-xdr]: https://github.com/davecgh/go-xdr


### PR DESCRIPTION
### What
Fix the links and images for the buttons at the top, and the reference link in the thanks section.

### Why
I merged #6 without checking the markdown actually rendered properly on GitHub, and I hadn't written the links properly.