### PR TITLE
Update Go versions to 1.13 and 1.14 in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go: [1.12, 1.13]
+        go: [1.13, 1.14]
     runs-on: ubuntu-latest
     container: golang:${{ matrix.go }}-stretch
     steps:


### PR DESCRIPTION
### What
Update Go versions to 1.13 and 1.14 in GitHub Actions build.

### Why
The GitHub Action build is using 1.12 and 1.13, but newer versions exist.