### PR TITLE
Fix decoding union into a previously used object

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -509,11 +509,23 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int) (
 	return n, nil
 }
 
+func setUnionArmsToNil(v reflect.Value) {
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.Ptr {
+			continue
+		}
+		v.Set(reflect.Zero(v.Type()))
+	}
+}
+
 // decodeUnion
 func (d *Decoder) decodeUnion(v reflect.Value) (int, error) {
 	// we should have already checked that v is a union
 	// prior to this call, so we panic if v is not a union
 	u := v.Interface().(Union)
+
+	setUnionArmsToNil(v)
 
 	i, n, err := d.DecodeInt()
 	if err != nil {

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -1053,3 +1053,47 @@ func TestPaddedReads(t *testing.T) {
 		t.Error("expected error when unmarshaling varopaque with non-zero padding byte, got none")
 	}
 }
+
+func TestDecodeUnionIntoExistingObject(t *testing.T) {
+	var buf bytes.Buffer
+	var idata int32 = 1
+	sdata := "data"
+	_, err := Marshal(&buf, aUnion{
+		Type: 0,
+		Data: &idata,
+	})
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	var s aUnion
+	_, err = Unmarshal(&buf, &s)
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	_, err = Marshal(&buf, aUnion{
+		Type: 1,
+		Text: &sdata,
+	})
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	_, err = Unmarshal(&buf, &s)
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	if s.Data != nil {
+		t.Error("Data should be nil")
+	}
+
+	if s.Type != 1 {
+		t.Error("Type does not match")
+	}
+
+	if *s.Text != sdata {
+		t.Error("Text does not match")
+	}
+}


### PR DESCRIPTION
This commit fixes a bug in `Decoder.decodeUnion`. When decoding a union previously used object (ex. in a loop with object created outside of the loop) the previous arm value was not zeroed (set to `nil`) if it was a different union type. See `TestDecodeUnionIntoExistingObject` for more context.