### PR TITLE
Make encoder/decoder underlying errors unwrappable

### DIFF
--- a/xdr3/error.go
+++ b/xdr3/error.go
@@ -106,6 +106,11 @@ type UnmarshalError struct {
 	Err         error       // The underlying error for IO errors
 }
 
+// Unwrap returns the underlying error if there is one.
+func (e *UnmarshalError) Unwrap() error {
+	return e.Err
+}
+
 // Error satisfies the error interface and prints human-readable errors.
 func (e *UnmarshalError) Error() string {
 	switch e.ErrorCode {
@@ -143,6 +148,11 @@ type MarshalError struct {
 	Value       interface{} // Value actually parsed where appropriate
 	Description string      // Human readable description of the issue
 	Err         error       // The underlying error for IO errors
+}
+
+// Unwrap returns the underlying error if there is one.
+func (e *MarshalError) Unwrap() error {
+	return e.Err
 }
 
 // Error satisfies the error interface and prints human-readable errors.

--- a/xdr3/error_test.go
+++ b/xdr3/error_test.go
@@ -17,6 +17,8 @@
 package xdr_test
 
 import (
+	"errors"
+	"io"
 	"testing"
 
 	. "github.com/stellar/go-xdr/xdr3"
@@ -66,6 +68,16 @@ func TestUnmarshalError(t *testing.T) {
 		},
 		{
 			UnmarshalError{
+				ErrorCode:   ErrIO,
+				Func:        "test",
+				Description: "underlying io error",
+				Value:       "testval",
+				Err:         io.ErrShortBuffer,
+			},
+			"xdr:test: underlying io error - read: 'testval'",
+		},
+		{
+			UnmarshalError{
 				ErrorCode:   ErrBadEnumValue,
 				Func:        "test",
 				Description: "invalid enum",
@@ -91,6 +103,10 @@ func TestUnmarshalError(t *testing.T) {
 				test.want)
 			continue
 		}
+		if test.in.Err != nil && !errors.Is(&test.in, test.in.Err) {
+			t.Errorf("Error #%d\n is not is-able on underlying error", i)
+			continue
+		}
 	}
 }
 
@@ -106,8 +122,19 @@ func TestMarshalError(t *testing.T) {
 				Func:        "test",
 				Description: "EOF while encoding 5 bytes",
 				Value:       []byte{0x01, 0x02},
+				Err:         io.EOF,
 			},
 			"xdr:test: EOF while encoding 5 bytes - wrote: '[1 2]'",
+		},
+		{
+			MarshalError{
+				ErrorCode:   ErrIO,
+				Func:        "test",
+				Description: "underlying io error",
+				Value:       []byte{0x01, 0x02},
+				Err:         io.ErrShortWrite,
+			},
+			"xdr:test: underlying io error - wrote: '[1 2]'",
 		},
 		{
 			MarshalError{
@@ -134,6 +161,10 @@ func TestMarshalError(t *testing.T) {
 		if result != test.want {
 			t.Errorf("Error #%d\n got: %s want: %s", i, result,
 				test.want)
+			continue
+		}
+		if test.in.Err != nil && !errors.Is(&test.in, test.in.Err) {
+			t.Errorf("Error #%d\n is not is-able on underlying error", i)
 			continue
 		}
 	}

--- a/xdr3/error_test.go
+++ b/xdr3/error_test.go
@@ -122,7 +122,6 @@ func TestMarshalError(t *testing.T) {
 				Func:        "test",
 				Description: "EOF while encoding 5 bytes",
 				Value:       []byte{0x01, 0x02},
-				Err:         io.EOF,
 			},
 			"xdr:test: EOF while encoding 5 bytes - wrote: '[1 2]'",
 		},


### PR DESCRIPTION
### What
Add `Unwrap` methods to the `MarshalError` and `UnmarshalError` types that return the underlying IO errors if present.

### Why
The `MarshalError` and `UnmarshalError` error types wrap IO and other errors. Since Go 1.13 if an error provides an `Unwrap` function that returns the underlying error, the `errors` stdlib package can be used to test if the error or any of its underlying errors are an error. This is helpful for testing for general underlying IO errors in code the uses the encoder/decoder as a reader.
