### PR TITLE
Add Marshaler and Unmarshaler interfaces

### DIFF
--- a/xdr3/error.go
+++ b/xdr3/error.go
@@ -70,20 +70,25 @@ const (
 	// ErrBadUnionValue indicates a union's value is not populated when it should
 	// be
 	ErrBadUnionValue
+
+	// ErrCustomUnaddressableByPointer indicates that an unaddresable value that implements Marshaler/Unmarshaler
+	// by pointer was passed and, as a result, the custom marshaler/unmarshaler cannot be invoked
+	ErrCustomUnaddressableByPointer
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
-	ErrBadArguments:    "ErrBadArguments",
-	ErrUnsupportedType: "ErrUnsupportedType",
-	ErrBadEnumValue:    "ErrBadEnumValue",
-	ErrNotSettable:     "ErrNotSettable",
-	ErrOverflow:        "ErrOverflow",
-	ErrNilInterface:    "ErrNilInterface",
-	ErrIO:              "ErrIO",
-	ErrParseTime:       "ErrParseTime",
-	ErrBadUnionSwitch:  "ErrBadUnionSwitch",
-	ErrBadUnionValue:   "ErrBadUnionValue",
+	ErrBadArguments:                 "ErrBadArguments",
+	ErrUnsupportedType:              "ErrUnsupportedType",
+	ErrBadEnumValue:                 "ErrBadEnumValue",
+	ErrNotSettable:                  "ErrNotSettable",
+	ErrOverflow:                     "ErrOverflow",
+	ErrNilInterface:                 "ErrNilInterface",
+	ErrIO:                           "ErrIO",
+	ErrParseTime:                    "ErrParseTime",
+	ErrBadUnionSwitch:               "ErrBadUnionSwitch",
+	ErrBadUnionValue:                "ErrBadUnionValue",
+	ErrCustomUnaddressableByPointer: "ErrCustomUnaddressableByPointer",
 }
 
 // String returns the ErrorCode as a human-readable name.


### PR DESCRIPTION
Add Marshaler and Unmarshaler interfaces, which allow for custom encoding/decoding
working similarly to `encoding/json` [Marshaler](https://pkg.go.dev/encoding/json#Marshaler) and [Unmarshaler](https://pkg.go.dev/encoding/json#Marshaler):

```go
type Marshaler interface {
	MarshalXDR(e *Encoder) (int, error)
}

type Unmarshaler interface {
	UnmarshalXDR(e *Decoder) (int, error)
}
```

The Decoder and Encoder automatically call the relevant methods if found.

Both implementation by value and by pointer are supported.

A new error (`ErrCustomUnaddressableByPointer`) will be returned if
a by-pointer implementation is found but the value passed is unaddressable
(not allowing to call the method by pointer).

Note that `Marshaler` is intended to override the `EncodeTo` methods introduced at https://github.com/stellar/go/pull/3957 . I will later update xdrgen to generate `MarshalXDR` implementations instead.