### PR TITLE
decoder: sanity-check the length of slices/maps before allocating them

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -33,6 +33,28 @@ var errIODecode = "%s while decoding %d bytes"
 // DecodeDefaultMaxDepth is the default maximum decoding depth
 const DecodeDefaultMaxDepth = 200
 
+// DecodeOptions configures how Decoding is done.
+type DecodeOptions struct {
+	// MaxDepth is the maximum decoding depth (i.e. maximum nesting of data structures).
+	// It prevents infinite recursions in cyclic datastructures and determines the maximum callstack growth.
+	// If set to 0, DecodeDefaultMaxDepth will be used.
+	MaxDepth uint
+
+	// MaxInputLen sets the maximum input size. It is used by the decoder to sanity-check
+	// allocation sizes and avoid heap explosions from doctored inputs.
+	//
+	// If set to 0, the decoder will try to figure out the input size by checking whether
+	// the provided io.Reader implements Len() (e.g. strings.Reader, bytes.Reader and bytes.Buffer do).
+	// Otherwise, no sanity checks will be done.
+	MaxInputLen int
+}
+
+// DefaultDecodeOptions are the default decoding options.
+var DefaultDecodeOptions = DecodeOptions{
+	MaxDepth:    DecodeDefaultMaxDepth,
+	MaxInputLen: 0,
+}
+
 /*
 Unmarshal parses XDR-encoded data into the value pointed to by v reading from
 reader r and returning the total number of bytes read.  An addressable pointer
@@ -66,7 +88,7 @@ by v and performs a mapping of underlying XDR types to Go types as follows:
 Notes and Limitations:
 
   - Automatic unmarshalling of variable and fixed-length arrays of uint8s
-    requires a special struct tag `xdropaque:"false"` since byte slices
+    requires a special struct tag xdropaque:"false" since byte slices
     and byte arrays are assumed to be opaque data and byte is a Go alias
     for uint8 thus indistinguishable under reflection
   - Cyclic data structures are not supported and will result in ErrMaxDecodingDepth errors
@@ -78,12 +100,15 @@ potential issues are unsupported Go types, attempting to decode a value which is
 too large to fit into a specified Go type, and exceeding max slice limitations.
 */
 func Unmarshal(r io.Reader, v interface{}) (int, error) {
-	d := newDecoder(r)
+	d := NewDecoder(r)
 	return d.Decode(v)
 }
 
-// lenLeft tells you how many bytes are left to read.
-// It is satisfied by io.Readers like bytes.Buffer, bytes.Reader
+// UnmarshalWithOptions works like Unmarshal but accepts decoding options.
+func UnmarshalWithOptions(r io.Reader, v interface{}, options DecodeOptions) (int, error) {
+	d := NewDecoderWithOptions(r, options)
+	return d.Decode(v)
+}
 
 type lenLeft interface {
 	Len() int
@@ -95,7 +120,7 @@ type lenLeft interface {
 // used to get a new Decoder directly.
 //
 // Typically, Unmarshal should be used instead of manual decoding.  A Decoder
-// is exposed so it is possible to perform manual decoding should it be
+// is exposed, so it is possible to perform manual decoding should it be
 // necessary in complex scenarios where automatic reflection-based decoding
 // won't work.
 type Decoder struct {
@@ -103,14 +128,53 @@ type Decoder struct {
 	scratchBuf [8]byte
 	r          io.Reader
 	l          lenLeft
+	maxDepth   uint
 }
 
-func newDecoder(r io.Reader) *Decoder {
-	d := &Decoder{r: r}
-	if l, ok := r.(lenLeft); ok {
-		d.l = l
+// readerLenWrapper wraps a reader an initial length and provides a Len() method indicating
+// how much input is left
+type readerLenWrapper struct {
+	inner      io.Reader
+	readCount  int
+	initialLen int
+}
+
+func (l *readerLenWrapper) Len() int {
+	return l.initialLen - l.readCount
+}
+
+func (l *readerLenWrapper) Read(p []byte) (int, error) {
+	n, err := l.inner.Read(p)
+	if n > 0 {
+		l.readCount += n
 	}
-	return d
+	return n, err
+}
+
+// NewDecoder returns a Decoder that can be used to manually decode XDR data
+// from a provided reader. Typically, Unmarshal should be used instead of
+// manually creating a Decoder.
+func NewDecoder(r io.Reader) *Decoder {
+	return NewDecoderWithOptions(r, DefaultDecodeOptions)
+}
+
+// NewDecoderWithOptions works like NewDecoder but allows supplying decoding options.
+func NewDecoderWithOptions(r io.Reader, options DecodeOptions) *Decoder {
+	maxDepth := options.MaxDepth
+	if maxDepth < 1 {
+		maxDepth = DecodeDefaultMaxDepth
+	}
+	if l, ok := r.(lenLeft); ok {
+		return &Decoder{r: r, l: l, maxDepth: maxDepth}
+	}
+	if options.MaxInputLen > 0 {
+		rlw := &readerLenWrapper{
+			inner:      r,
+			initialLen: options.MaxInputLen,
+		}
+		return &Decoder{r: rlw, l: rlw, maxDepth: maxDepth}
+	}
+	return &Decoder{r: r, l: nil, maxDepth: options.MaxDepth}
 }
 
 // DecodeInt treats the next 4 bytes as an XDR encoded integer and returns the
@@ -753,7 +817,6 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 	// Allocate storage for the underlying map if needed.
 	vt := v.Type()
 	if v.IsNil() {
-		// We assume that the map allocation won't exceed d.maxAllocSize
 		v.Set(reflect.MakeMap(vt))
 	}
 
@@ -1089,11 +1152,6 @@ func (d *Decoder) indirectIfPtr(v reflect.Value) (reflect.Value, error) {
 // data instead of a user-supplied reader. See the Unmarhsal documentation for
 // specifics. Decode(v) is equivalent to DecodeWithMaxDepth(v, DecodeDefaultMaxDepth)
 func (d *Decoder) Decode(v interface{}) (int, error) {
-	return d.DecodeWithMaxDepth(v, DecodeDefaultMaxDepth)
-}
-
-// DecodeWithMaxDepth behaves like Decode, except an explicit maximum decoding depth is used
-func (d *Decoder) DecodeWithMaxDepth(v interface{}, maxDepth uint) (int, error) {
 	if v == nil {
 		msg := "can't unmarshal to nil interface"
 		return 0, unmarshalError("Unmarshal", ErrNilInterface, msg, nil,
@@ -1114,7 +1172,7 @@ func (d *Decoder) DecodeWithMaxDepth(v interface{}, maxDepth uint) (int, error) 
 		return 0, err
 	}
 
-	return d.decode(vv.Elem(), 0, maxDepth)
+	return d.decode(vv.Elem(), 0, d.maxDepth)
 }
 
 // InputLen returns the size left to read from the decoder's input if available
@@ -1123,11 +1181,4 @@ func (d *Decoder) InputLen() (int, bool) {
 		return 0, false
 	}
 	return d.l.Len(), true
-}
-
-// NewDecoder returns a Decoder that can be used to manually decode XDR data
-// from a provided reader.  Typically, Unmarshal should be used instead of
-// manually creating a Decoder.
-func NewDecoder(r io.Reader) *Decoder {
-	return newDecoder(r)
 }

--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -399,7 +399,7 @@ func (d *Decoder) DecodeOpaque(maxSize int) ([]byte, int, error) {
 		return nil, n, err
 	}
 
-	maxSize = d.mergeLenLeftAndMaxSize(maxSize)
+	maxSize = d.mergeInputLenAndMaxSize(maxSize)
 	if maxSize == 0 {
 		maxSize = maxInt32
 	}
@@ -439,7 +439,7 @@ func (d *Decoder) DecodeString(maxSize int) (string, int, error) {
 		return "", n, err
 	}
 
-	maxSize = d.mergeLenLeftAndMaxSize(maxSize)
+	maxSize = d.mergeInputLenAndMaxSize(maxSize)
 	if maxSize == 0 {
 		maxSize = maxInt32
 	}
@@ -513,7 +513,7 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int, m
 		return n, err
 	}
 
-	maxSize = d.mergeLenLeftAndMaxSize(maxSize)
+	maxSize = d.mergeInputLenAndMaxSize(maxSize)
 	if maxSize == 0 {
 		maxSize = maxInt32
 	}
@@ -744,8 +744,7 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 	if err != nil {
 		return n, err
 	}
-	if d.l != nil {
-		left := d.l.Len()
+	if left, ok := d.InputLen(); ok {
 		if uint(left) < uint(dataLen) {
 			return 0, unmarshalError("decodeMap", ErrOverflow, errMaxSlice, dataLen, nil)
 		}
@@ -813,10 +812,10 @@ func (d *Decoder) decodeInterface(v reflect.Value, maxDepth uint) (int, error) {
 	return d.decode(ve, 0, maxDepth)
 }
 
-func (d *Decoder) mergeLenLeftAndMaxSize(maxSize int) int {
-	if d.l != nil {
-		if maxSize == 0 || d.l.Len() < maxSize {
-			return d.l.Len()
+func (d *Decoder) mergeInputLenAndMaxSize(maxSize int) int {
+	if left, ok := d.InputLen(); ok {
+		if maxSize == 0 || left < maxSize {
+			return left
 		}
 	}
 	return maxSize
@@ -1116,6 +1115,14 @@ func (d *Decoder) DecodeWithMaxDepth(v interface{}, maxDepth uint) (int, error) 
 	}
 
 	return d.decode(vv.Elem(), 0, maxDepth)
+}
+
+// InputLen returns the size left to read from the decoder's input if available
+func (d *Decoder) InputLen() (int, bool) {
+	if d.l == nil {
+		return 0, false
+	}
+	return d.l.Len(), true
 }
 
 // NewDecoder returns a Decoder that can be used to manually decode XDR data

--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -746,7 +746,7 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 	}
 	if left, ok := d.InputLen(); ok {
 		if uint(left) < uint(dataLen) {
-			return 0, unmarshalError("decodeMap", ErrOverflow, errMaxSlice, dataLen, nil)
+			return n, unmarshalError("decodeMap", ErrOverflow, errMaxSlice, dataLen, nil)
 		}
 	}
 

--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -25,9 +25,10 @@ import (
 	"time"
 )
 
-const maxInt32 = int(^uint32(0) >> 1)
+const maxInt32 = math.MaxInt32
 
 var errMaxSlice = "data exceeds max slice limit"
+var errMaxAllocation = "allocation would exceed the maximum limit"
 var errIODecode = "%s while decoding %d bytes"
 
 // DecodeDefaultMaxDepth is the default maximum decoding depth
@@ -93,8 +94,9 @@ func Unmarshal(r io.Reader, v interface{}) (int, error) {
 // won't work.
 type Decoder struct {
 	// used to minimize heap allocations during decoding
-	scratchBuf [8]byte
-	r          io.Reader
+	scratchBuf   [8]byte
+	r            io.Reader
+	maxAllocSize int
 }
 
 // DecodeInt treats the next 4 bytes as an XDR encoded integer and returns the
@@ -477,7 +479,7 @@ func (d *Decoder) decodeFixedArray(v reflect.Value, ignoreOpaque bool, maxDepth 
 // elements of the same type as the array represented by the reflection value.
 // The number of elements is obtained by first decoding the unsigned integer
 // element count.  Then each element is decoded into the passed array. The
-// ignoreOpaque flag controls whether or not uint8 (byte) elements should be
+// ignoreOpaque flag controls whether uint8 (byte) elements should be
 // decoded individually or as a variable sequence of opaque data.  It returns
 // the number of bytes actually read.
 //
@@ -509,6 +511,10 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int, m
 	// existing slice does not have enough capacity.
 	sliceLen := int(dataLen)
 	if v.Cap() < sliceLen {
+		growth := (sliceLen - v.Cap()) * int(v.Type().Size())
+		if growth > d.maxAllocSize {
+			return 0, unmarshalError("decodeArray", ErrOverflow, errMaxAllocation, nil, nil)
+		}
 		v.Set(reflect.MakeSlice(v.Type(), sliceLen, sliceLen))
 	}
 	v.SetLen(sliceLen)
@@ -591,7 +597,11 @@ func (d *Decoder) decodeUnion(v reflect.Value, maxDepth uint) (int, error) {
 
 	vv := v.FieldByName(arm)
 
-	vv.Set(reflect.New(vv.Type().Elem()))
+	vvet := vv.Type().Elem()
+	if d.maxAllocSize < int(vvet.Size()) {
+		return 0, unmarshalError("decode", ErrOverflow, errMaxAllocation, nil, nil)
+	}
+	vv.Set(reflect.New(vvet))
 
 	field, ok := v.Type().FieldByName(arm)
 	if !ok {
@@ -621,8 +631,8 @@ func (d *Decoder) decodeUnion(v reflect.Value, maxDepth uint) (int, error) {
 
 // decodeStruct treats the next bytes as a series of XDR encoded elements
 // of the same type as the exported fields of the struct represented by the
-// passed reflection value.  Pointers are automatically indirected and
-// allocated as necessary.  It returns the  the number of bytes actually read.
+// passed reflection value. Pointers are automatically indirected and
+// allocated as necessary. It returns the number of bytes actually read.
 //
 // An UnmarshalError is returned if any issues are encountered while decoding
 // the elements.
@@ -728,12 +738,16 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 	// Allocate storage for the underlying map if needed.
 	vt := v.Type()
 	if v.IsNil() {
+		// We assume that the map allocation won't exceed d.maxAllocSize
 		v.Set(reflect.MakeMap(vt))
 	}
 
 	// Decode each key and value according to their type.
 	keyType := vt.Key()
 	elemType := vt.Elem()
+	if uintptr(d.maxAllocSize) < keyType.Size()+elemType.Size()*uintptr(dataLen) {
+		return 0, unmarshalError("decode", ErrOverflow, errMaxAllocation, nil, nil)
+	}
 	for i := uint32(0); i < dataLen; i++ {
 		key := reflect.New(keyType).Elem()
 		n2, err := d.decode(key, 0, maxDepth)
@@ -756,7 +770,7 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 // decodeInterface examines the interface represented by the passed reflection
 // value to detect whether it is an interface that can be decoded into and
 // if it is, extracts the underlying value to pass back into the decode function
-// for decoding according to its type.  It returns the  the number of bytes
+// for decoding according to its type. It returns the number of bytes
 // actually read.
 //
 // An UnmarshalError is returned if any issues are encountered while decoding
@@ -786,6 +800,14 @@ func (d *Decoder) decodeInterface(v reflect.Value, maxDepth uint) (int, error) {
 	return d.decode(ve, 0, maxDepth)
 }
 
+func (d *Decoder) mergeMaxAllocSizeAndMaxSize(maxSize int) int {
+	if maxSize == 0 ||
+		d.maxAllocSize < maxSize {
+		return d.maxAllocSize
+	}
+	return maxSize
+}
+
 // decode is the main workhorse for unmarshalling via reflection.  It uses
 // the passed reflection value to choose the XDR primitives to decode from
 // the encapsulated reader.  It is a recursive function,
@@ -809,6 +831,7 @@ func (d *Decoder) decode(ve reflect.Value, maxSize int, maxDepth uint) (int, err
 	// since checking a string is much quicker.
 	if ve.Type().String() == "time.Time" {
 		// Read the value as a string and parse it.
+		maxSize = d.mergeMaxAllocSizeAndMaxSize(maxSize)
 		timeString, n, err := d.DecodeString(maxSize)
 		if err != nil {
 			return n, err
@@ -911,6 +934,7 @@ func (d *Decoder) decode(ve reflect.Value, maxSize int, maxDepth uint) (int, err
 			maxSize = dest.XDRMaxSize()
 		}
 
+		maxSize = d.mergeMaxAllocSizeAndMaxSize(maxSize)
 		s, n, err := d.DecodeString(maxSize)
 		if err != nil {
 			return n, err
@@ -993,7 +1017,7 @@ func setPtrToNil(v *reflect.Value) error {
 	return nil
 }
 
-func allocPtrIfNil(v *reflect.Value) error {
+func (d *Decoder) allocPtrIfNil(v *reflect.Value) error {
 	if v.Kind() != reflect.Ptr {
 		msg := fmt.Sprintf("value is not a pointer: '%v'",
 			v.Type().String())
@@ -1010,7 +1034,11 @@ func allocPtrIfNil(v *reflect.Value) error {
 		return err
 	}
 	if isNil {
-		v.Set(reflect.New(v.Type().Elem()))
+		vet := v.Type().Elem()
+		if d.maxAllocSize < int(vet.Size()) {
+			return unmarshalError("decode", ErrOverflow, errMaxAllocation, nil, nil)
+		}
+		v.Set(reflect.New(vet))
 	}
 	return nil
 }
@@ -1030,7 +1058,7 @@ func (d *Decoder) decodePtr(v reflect.Value, maxDepth uint) (int, error) {
 		return n, err
 	}
 
-	if err = allocPtrIfNil(&v); err != nil {
+	if err = d.allocPtrIfNil(&v); err != nil {
 		return n, err
 	}
 
@@ -1042,7 +1070,7 @@ func (d *Decoder) decodePtr(v reflect.Value, maxDepth uint) (int, error) {
 // otherwise returns the passed value.
 func (d *Decoder) indirectIfPtr(v reflect.Value) (reflect.Value, error) {
 	if v.Kind() == reflect.Ptr {
-		err := allocPtrIfNil(&v)
+		err := d.allocPtrIfNil(&v)
 		return v.Elem(), err
 	}
 	return v, nil
@@ -1053,11 +1081,25 @@ func (d *Decoder) indirectIfPtr(v reflect.Value) (reflect.Value, error) {
 // data instead of a user-supplied reader. See the Unmarhsal documentation for
 // specifics. Decode(v) is equivalent to DecodeWithMaxDepth(v, DecodeDefaultMaxDepth)
 func (d *Decoder) Decode(v interface{}) (int, error) {
-	return d.DecodeWithMaxDepth(v, DecodeDefaultMaxDepth)
+	return d.DecodeWithMaxDepthAndMaxAllocSize(v, DecodeDefaultMaxDepth, 0)
 }
 
 // DecodeWithMaxDepth behaves like Decode, except an explicit maximum decoding depth is used
 func (d *Decoder) DecodeWithMaxDepth(v interface{}, maxDepth uint) (int, error) {
+	return d.DecodeWithMaxDepthAndMaxAllocSize(v, maxDepth, 0)
+}
+
+// DecodeWithMaxDepthAndMaxAllocSize behaves like DecodeWithMaxDepth, except an explicit maximum
+// allocation size is used. This is meant to protect against XDR doctored to cause a heap explosion.
+// The decoder won't make any allocation larger than maxAllocSize
+func (d *Decoder) DecodeWithMaxDepthAndMaxAllocSize(v interface{}, maxDepth uint, maxAllocSize int) (int, error) {
+	if maxAllocSize == 0 {
+		maxAllocSize = maxInt32
+	}
+	d.maxAllocSize = maxAllocSize
+	defer func() {
+		d.maxAllocSize = 0
+	}()
 	if v == nil {
 		msg := "can't unmarshal to nil interface"
 		return 0, unmarshalError("Unmarshal", ErrNilInterface, msg, nil,

--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -28,7 +28,6 @@ import (
 const maxInt32 = math.MaxInt32
 
 var errMaxSlice = "data exceeds max slice limit"
-var errMaxAllocation = "allocation would exceed the maximum limit"
 var errIODecode = "%s while decoding %d bytes"
 
 // DecodeDefaultMaxDepth is the default maximum decoding depth
@@ -79,8 +78,15 @@ potential issues are unsupported Go types, attempting to decode a value which is
 too large to fit into a specified Go type, and exceeding max slice limitations.
 */
 func Unmarshal(r io.Reader, v interface{}) (int, error) {
-	d := Decoder{r: r}
+	d := newDecoder(r)
 	return d.Decode(v)
+}
+
+// lenLeft tells you how many bytes are left to read.
+// It is satisfied by io.Readers like bytes.Buffer, bytes.Reader
+
+type lenLeft interface {
+	Len() int
 }
 
 // A Decoder wraps an io.Reader that is expected to provide an XDR-encoded byte
@@ -94,9 +100,17 @@ func Unmarshal(r io.Reader, v interface{}) (int, error) {
 // won't work.
 type Decoder struct {
 	// used to minimize heap allocations during decoding
-	scratchBuf   [8]byte
-	r            io.Reader
-	maxAllocSize int
+	scratchBuf [8]byte
+	r          io.Reader
+	l          lenLeft
+}
+
+func newDecoder(r io.Reader) *Decoder {
+	d := &Decoder{r: r}
+	if l, ok := r.(lenLeft); ok {
+		d.l = l
+	}
+	return d
 }
 
 // DecodeInt treats the next 4 bytes as an XDR encoded integer and returns the
@@ -385,6 +399,7 @@ func (d *Decoder) DecodeOpaque(maxSize int) ([]byte, int, error) {
 		return nil, n, err
 	}
 
+	maxSize = d.mergeLenLeftAndMaxSize(maxSize)
 	if maxSize == 0 {
 		maxSize = maxInt32
 	}
@@ -424,6 +439,7 @@ func (d *Decoder) DecodeString(maxSize int) (string, int, error) {
 		return "", n, err
 	}
 
+	maxSize = d.mergeLenLeftAndMaxSize(maxSize)
 	if maxSize == 0 {
 		maxSize = maxInt32
 	}
@@ -497,6 +513,7 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int, m
 		return n, err
 	}
 
+	maxSize = d.mergeLenLeftAndMaxSize(maxSize)
 	if maxSize == 0 {
 		maxSize = maxInt32
 	}
@@ -511,10 +528,6 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int, m
 	// existing slice does not have enough capacity.
 	sliceLen := int(dataLen)
 	if v.Cap() < sliceLen {
-		growth := (sliceLen - v.Cap()) * int(v.Type().Size())
-		if growth > d.maxAllocSize {
-			return 0, unmarshalError("decodeArray", ErrOverflow, errMaxAllocation, nil, nil)
-		}
 		v.Set(reflect.MakeSlice(v.Type(), sliceLen, sliceLen))
 	}
 	v.SetLen(sliceLen)
@@ -598,9 +611,6 @@ func (d *Decoder) decodeUnion(v reflect.Value, maxDepth uint) (int, error) {
 	vv := v.FieldByName(arm)
 
 	vvet := vv.Type().Elem()
-	if d.maxAllocSize < int(vvet.Size()) {
-		return 0, unmarshalError("decode", ErrOverflow, errMaxAllocation, nil, nil)
-	}
 	vv.Set(reflect.New(vvet))
 
 	field, ok := v.Type().FieldByName(arm)
@@ -734,6 +744,12 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 	if err != nil {
 		return n, err
 	}
+	if d.l != nil {
+		left := d.l.Len()
+		if uint(left) < uint(dataLen) {
+			return 0, unmarshalError("decodeMap", ErrOverflow, errMaxSlice, dataLen, nil)
+		}
+	}
 
 	// Allocate storage for the underlying map if needed.
 	vt := v.Type()
@@ -745,9 +761,6 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 	// Decode each key and value according to their type.
 	keyType := vt.Key()
 	elemType := vt.Elem()
-	if uintptr(d.maxAllocSize) < keyType.Size()+elemType.Size()*uintptr(dataLen) {
-		return 0, unmarshalError("decode", ErrOverflow, errMaxAllocation, nil, nil)
-	}
 	for i := uint32(0); i < dataLen; i++ {
 		key := reflect.New(keyType).Elem()
 		n2, err := d.decode(key, 0, maxDepth)
@@ -800,10 +813,11 @@ func (d *Decoder) decodeInterface(v reflect.Value, maxDepth uint) (int, error) {
 	return d.decode(ve, 0, maxDepth)
 }
 
-func (d *Decoder) mergeMaxAllocSizeAndMaxSize(maxSize int) int {
-	if maxSize == 0 ||
-		d.maxAllocSize < maxSize {
-		return d.maxAllocSize
+func (d *Decoder) mergeLenLeftAndMaxSize(maxSize int) int {
+	if d.l != nil {
+		if maxSize == 0 || d.l.Len() < maxSize {
+			return d.l.Len()
+		}
 	}
 	return maxSize
 }
@@ -831,7 +845,6 @@ func (d *Decoder) decode(ve reflect.Value, maxSize int, maxDepth uint) (int, err
 	// since checking a string is much quicker.
 	if ve.Type().String() == "time.Time" {
 		// Read the value as a string and parse it.
-		maxSize = d.mergeMaxAllocSizeAndMaxSize(maxSize)
 		timeString, n, err := d.DecodeString(maxSize)
 		if err != nil {
 			return n, err
@@ -934,7 +947,6 @@ func (d *Decoder) decode(ve reflect.Value, maxSize int, maxDepth uint) (int, err
 			maxSize = dest.XDRMaxSize()
 		}
 
-		maxSize = d.mergeMaxAllocSizeAndMaxSize(maxSize)
 		s, n, err := d.DecodeString(maxSize)
 		if err != nil {
 			return n, err
@@ -1035,9 +1047,6 @@ func (d *Decoder) allocPtrIfNil(v *reflect.Value) error {
 	}
 	if isNil {
 		vet := v.Type().Elem()
-		if d.maxAllocSize < int(vet.Size()) {
-			return unmarshalError("decode", ErrOverflow, errMaxAllocation, nil, nil)
-		}
 		v.Set(reflect.New(vet))
 	}
 	return nil
@@ -1081,25 +1090,11 @@ func (d *Decoder) indirectIfPtr(v reflect.Value) (reflect.Value, error) {
 // data instead of a user-supplied reader. See the Unmarhsal documentation for
 // specifics. Decode(v) is equivalent to DecodeWithMaxDepth(v, DecodeDefaultMaxDepth)
 func (d *Decoder) Decode(v interface{}) (int, error) {
-	return d.DecodeWithMaxDepthAndMaxAllocSize(v, DecodeDefaultMaxDepth, 0)
+	return d.DecodeWithMaxDepth(v, DecodeDefaultMaxDepth)
 }
 
 // DecodeWithMaxDepth behaves like Decode, except an explicit maximum decoding depth is used
 func (d *Decoder) DecodeWithMaxDepth(v interface{}, maxDepth uint) (int, error) {
-	return d.DecodeWithMaxDepthAndMaxAllocSize(v, maxDepth, 0)
-}
-
-// DecodeWithMaxDepthAndMaxAllocSize behaves like DecodeWithMaxDepth, except an explicit maximum
-// allocation size is used. This is meant to protect against XDR doctored to cause a heap explosion.
-// The decoder won't make any allocation larger than maxAllocSize
-func (d *Decoder) DecodeWithMaxDepthAndMaxAllocSize(v interface{}, maxDepth uint, maxAllocSize int) (int, error) {
-	if maxAllocSize == 0 {
-		maxAllocSize = maxInt32
-	}
-	d.maxAllocSize = maxAllocSize
-	defer func() {
-		d.maxAllocSize = 0
-	}()
 	if v == nil {
 		msg := "can't unmarshal to nil interface"
 		return 0, unmarshalError("Unmarshal", ErrNilInterface, msg, nil,
@@ -1127,5 +1122,5 @@ func (d *Decoder) DecodeWithMaxDepthAndMaxAllocSize(v interface{}, maxDepth uint
 // from a provided reader.  Typically, Unmarshal should be used instead of
 // manually creating a Decoder.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r: r}
+	return newDecoder(r)
 }

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -361,7 +361,7 @@ func TestUnmarshal(t *testing.T) {
 		// element no extra bytes, 1 map element not enough bytes for
 		// key, 1 map element not enough bytes for value.
 		{[]byte{0x00, 0x00, 0x00}, map[string]uint32{}, 3, &UnmarshalError{ErrorCode: ErrIO}},
-		{[]byte{0x00, 0x00, 0x00, 0x01}, map[string]uint32{}, 4, &UnmarshalError{ErrorCode: ErrIO}},
+		{[]byte{0x00, 0x00, 0x00, 0x01}, map[string]uint32{}, 4, &UnmarshalError{ErrorCode: ErrOverflow}},
 		{[]byte{0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}, map[string]uint32{}, 7, &UnmarshalError{ErrorCode: ErrIO}},
 		{[]byte{0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x6D, 0x61, 0x70, 0x31},
 			map[string]uint32{}, 12, &UnmarshalError{ErrorCode: ErrIO}},

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -18,6 +18,7 @@ package xdr_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"reflect"
@@ -1143,20 +1144,20 @@ func TestDecodeMaxDepth(t *testing.T) {
 	}
 
 	bufCopy := buf
-	decoder := NewDecoder(&bufCopy)
+	decoder := NewDecoderWithOptions(&bufCopy, DecodeOptions{MaxDepth: 3})
 	var s structWithPointer
-	_, err = decoder.DecodeWithMaxDepth(&s, 3)
+	_, err = decoder.Decode(&s)
 	if err != nil {
 		t.Error("unexpected error")
 	}
 
 	bufCopy = buf
-	decoder = NewDecoder(&bufCopy)
-	_, err = decoder.DecodeWithMaxDepth(&s, 2)
+	decoder = NewDecoderWithOptions(&bufCopy, DecodeOptions{MaxDepth: 2})
+	_, err = decoder.Decode(&s)
 	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrMaxDecodingDepth})
 }
 
-func TestDecodeMaxAllocationCheck(t *testing.T) {
+func TestDecodeMaxAllocationCheck_ImplicitLenReader(t *testing.T) {
 	var buf bytes.Buffer
 	_, err := Marshal(&buf, "thisstringis23charslong")
 	if err != nil {
@@ -1164,12 +1165,30 @@ func TestDecodeMaxAllocationCheck(t *testing.T) {
 	}
 
 	// Reduce the buffer size so that the length of the buffer
-	// is shorter than the encoded string length
+	// is shorter than the encoded XDR  length
 	buf.Truncate(buf.Len() - 4)
 
-	bufCopy := buf
-	decoder := NewDecoder(&bufCopy)
+	decoder := NewDecoder(&buf)
 	var s string
-	_, err = decoder.DecodeWithMaxDepth(&s, DecodeDefaultMaxDepth)
+	_, err = decoder.Decode(&s)
+	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrOverflow})
+}
+
+func TestDecodeMaxAllocationCheck_ExplicitLenReader(t *testing.T) {
+	var buf bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+	_, err := Marshal(encoder, "thisstringis23charslong")
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	xdrLen := base64.StdEncoding.DecodedLen(buf.Len())
+	// Reduce the buffer size so that the length of the buffer
+	// is shorter than the encoded XDR length
+	reducedLen := xdrLen - 4
+
+	decoder := NewDecoderWithOptions(&buf, DecodeOptions{MaxInputLen: reducedLen})
+	var s string
+	_, err = decoder.Decode(&s)
 	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrOverflow})
 }

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -1156,23 +1156,20 @@ func TestDecodeMaxDepth(t *testing.T) {
 	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrMaxDecodingDepth})
 }
 
-func TestDecodeMaxAllocSize(t *testing.T) {
+func TestDecodeMaxAllocationCheck(t *testing.T) {
 	var buf bytes.Buffer
 	_, err := Marshal(&buf, "thisstringis23charslong")
 	if err != nil {
 		t.Error("unexpected error")
 	}
 
+	// Reduce the buffer size so that the length of the buffer
+	// is shorter than the encoded string length
+	buf.Truncate(buf.Len() - 4)
+
 	bufCopy := buf
 	decoder := NewDecoder(&bufCopy)
 	var s string
-	_, err = decoder.DecodeWithMaxDepthAndMaxAllocSize(&s, DecodeDefaultMaxDepth, 23)
-	if err != nil {
-		t.Error("unexpected error")
-	}
-
-	bufCopy = buf
-	decoder = NewDecoder(&bufCopy)
-	_, err = decoder.DecodeWithMaxDepthAndMaxAllocSize(&s, DecodeDefaultMaxDepth, 22)
+	_, err = decoder.DecodeWithMaxDepth(&s, DecodeDefaultMaxDepth)
 	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrOverflow})
 }

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -1155,3 +1155,24 @@ func TestDecodeMaxDepth(t *testing.T) {
 	_, err = decoder.DecodeWithMaxDepth(&s, 2)
 	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrMaxDecodingDepth})
 }
+
+func TestDecodeMaxAllocSize(t *testing.T) {
+	var buf bytes.Buffer
+	_, err := Marshal(&buf, "thisstringis23charslong")
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	bufCopy := buf
+	decoder := NewDecoder(&bufCopy)
+	var s string
+	_, err = decoder.DecodeWithMaxDepthAndMaxAllocSize(&s, DecodeDefaultMaxDepth, 23)
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	bufCopy = buf
+	decoder = NewDecoder(&bufCopy)
+	_, err = decoder.DecodeWithMaxDepthAndMaxAllocSize(&s, DecodeDefaultMaxDepth, 22)
+	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrOverflow})
+}

--- a/xdr3/error.go
+++ b/xdr3/error.go
@@ -43,7 +43,8 @@ const (
 	ErrNotSettable
 
 	// ErrOverflow indicates that the data in question is too large to fit
-	// into the corresponding Go or XDR data type.  For example, an integer
+	// into the corresponding Go or XDR data type or that allocating it exceeds the
+	// maximum allocation size limit.  For example, an integer
 	// decoded from XDR that is too large to fit into a target type of int8,
 	// or opaque data that exceeds the max length of a Go slice.
 	ErrOverflow

--- a/xdr3/internal_test.go
+++ b/xdr3/internal_test.go
@@ -37,7 +37,7 @@ func TstEncode(w io.Writer) func(v reflect.Value) (int, error) {
 
 // TstDecode creates a new Decoder for the passed reader and returns the
 // internal decode function on the Decoder.
-func TstDecode(r io.Reader) func(v reflect.Value, maxSize int, maxDepth uint) (int, error) {
+func TstDecode(r io.Reader) func(v reflect.Value, maxLen int, maxDepth uint) (int, error) {
 	dec := NewDecoder(r)
 	return dec.decode
 }


### PR DESCRIPTION
This is meant to protect against input XDR doctored to cause a heap explosion.

The decoder won't allocate any container (slice/map) with a length larger than the remaining size of the input reader (if available).
