### PR TITLE
decoder: raise default max depth to 1500 and add DecodeUnlimitedDepth

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -32,8 +32,12 @@ const maxInt32 = math.MaxInt32
 var errMaxSlice = "data exceeds max slice limit"
 var errIODecode = "%s while decoding %d bytes"
 
-// DecodeDefaultMaxDepth is the default maximum decoding depth
-const DecodeDefaultMaxDepth = 250
+// DecodeDefaultMaxDepth is the default maximum decoding depth.
+const DecodeDefaultMaxDepth = 1500
+
+// DecodeUnlimitedDepth disables the maximum decoding depth limit. Only use it
+// for trusted input.
+const DecodeUnlimitedDepth = uint(math.MaxUint)
 
 // MaxPrealloc is the maximum number of elements pre-allocated when decoding
 // variable-length arrays. Arrays larger than this are grown incrementally via
@@ -45,6 +49,7 @@ type DecodeOptions struct {
 	// MaxDepth is the maximum decoding depth (i.e. maximum nesting of data structures).
 	// It prevents infinite recursions in cyclic datastructures and determines the maximum callstack growth.
 	// If set to 0, DecodeDefaultMaxDepth will be used.
+	// Set it to DecodeUnlimitedDepth to disable the limit.
 	MaxDepth uint
 
 	// MaxInputLen sets the maximum input size. It is used by the decoder to sanity-check

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -1157,6 +1157,41 @@ func TestDecodeMaxDepth(t *testing.T) {
 	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrMaxDecodingDepth})
 }
 
+// linkedNode builds arbitrarily deep nesting for depth-limit tests.
+type linkedNode struct {
+	Next *linkedNode
+}
+
+func buildLinkedChain(depth int) *linkedNode {
+	var head *linkedNode
+	for i := 0; i < depth; i++ {
+		head = &linkedNode{Next: head}
+	}
+	return head
+}
+
+func TestDecodeUnlimitedDepth(t *testing.T) {
+	depth := DecodeDefaultMaxDepth + 100
+	var buf bytes.Buffer
+	if _, err := Marshal(&buf, buildLinkedChain(depth)); err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	// Default limit rejects the deeply nested input.
+	bufCopy := buf
+	var s linkedNode
+	_, err := NewDecoder(&bufCopy).Decode(&s)
+	assertError(t, "", err, &UnmarshalError{ErrorCode: ErrMaxDecodingDepth})
+
+	// DecodeUnlimitedDepth decodes it.
+	bufCopy = buf
+	var s2 linkedNode
+	_, err = NewDecoderWithOptions(&bufCopy, DecodeOptions{MaxDepth: DecodeUnlimitedDepth}).Decode(&s2)
+	if err != nil {
+		t.Fatalf("unexpected error decoding with unlimited depth: %v", err)
+	}
+}
+
 func TestDecodeMaxAllocationCheck_ImplicitLenReader(t *testing.T) {
 	var buf bytes.Buffer
 	_, err := Marshal(&buf, "thisstringis23charslong")


### PR DESCRIPTION
## What

- Raise `DecodeDefaultMaxDepth` from **250 → 1500**. This is the bound applied to untrusted, user-supplied XDR (anyone using `NewDecoder`/`Unmarshal` or `MaxDepth: 0`).
- Add a new sentinel `DecodeUnlimitedDepth = uint(math.MaxUint)`. Callers decoding **trusted** XDR (e.g. emitted by stellar-core) can set `DecodeOptions{MaxDepth: xdr3.DecodeUnlimitedDepth}` to disable the depth limit.

## Why

The previous default of 250 was too shallow for some legitimately deep XDR. User-supplied input still needs a guard against unbounded recursion / stack growth, so the default is raised to 1500 rather than removed. Trusted core output, which is acyclic and finite but can nest deeply, gets an explicit opt-out.

## Usage

```go
// User-supplied / untrusted XDR — capped at 1500
xdr3.Unmarshal(r, &v)

// Trusted XDR emitted by stellar-core — no depth limit
xdr3.UnmarshalWithOptions(r, &v, xdr3.DecodeOptions{
    MaxDepth: xdr3.DecodeUnlimitedDepth,
})
```

## Implementation notes

- `0` already means "use the default", so a separate sentinel was needed for "unlimited". `math.MaxUint` reuses the existing countdown logic untouched — no hot-path change — and is effectively unbounded for any real nesting.
- Trade-off: `DecodeUnlimitedDepth` is not *truly* unbounded; a genuinely cyclic/adversarial input would no longer be caught by the depth check. That's intended, since this knob is only for trusted input (documented on the constant).

## Testing

- Added `TestDecodeUnlimitedDepth`: builds a chain nested 100 levels past the default, confirms the default limit rejects it (`ErrMaxDecodingDepth`) and `DecodeUnlimitedDepth` decodes it cleanly.
- Full suite green across `xdr`, `xdr2`, `xdr3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)