### PR TITLE
decoder: reject length prefix that exhausts input instead of dropping the bound

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -503,9 +503,6 @@ func (d *Decoder) DecodeOpaque(maxSize int) ([]byte, int, error) {
 	}
 
 	maxSize = d.mergeInputLenAndMaxSize(maxSize)
-	if maxSize == 0 {
-		maxSize = maxInt32
-	}
 
 	if uint(dataLen) > uint(maxSize) {
 		err := unmarshalError("DecodeOpaque", ErrOverflow, errMaxSlice,
@@ -543,9 +540,6 @@ func (d *Decoder) DecodeString(maxSize int) (string, int, error) {
 	}
 
 	maxSize = d.mergeInputLenAndMaxSize(maxSize)
-	if maxSize == 0 {
-		maxSize = maxInt32
-	}
 
 	if uint(dataLen) > uint(maxSize) {
 		err = unmarshalError("DecodeString", ErrOverflow, errMaxSlice,
@@ -617,9 +611,6 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int, m
 	}
 
 	maxSize = d.mergeInputLenAndMaxSize(maxSize)
-	if maxSize == 0 {
-		maxSize = maxInt32
-	}
 
 	if uint(dataLen) > uint(maxSize) {
 		err := unmarshalError("decodeArray", ErrOverflow, errMaxSlice,
@@ -878,6 +869,12 @@ func (d *Decoder) decodeMap(v reflect.Value, maxDepth uint) (int, error) {
 		return n, err
 	}
 	if left, ok := d.InputLen(); ok {
+		// Clamp defensively so a negative remaining length (a miscounting
+		// reader) rejects any non-zero declared length rather than wrapping
+		// to a huge uint. Mirrors mergeInputLenAndMaxSize's max(0, left).
+		if left < 0 {
+			left = 0
+		}
 		if uint(left) < uint(dataLen) {
 			return n, unmarshalError("decodeMap", ErrOverflow, errMaxSlice, dataLen, nil)
 		}
@@ -952,11 +949,27 @@ func (d *Decoder) decodeInterface(v reflect.Value, maxDepth uint) (int, error) {
 	return d.decode(ve, 0, maxDepth)
 }
 
+// mergeInputLenAndMaxSize returns the effective upper bound on the length of the
+// next variable-length field: the tighter of two independently-optional limits,
+// each defaulting to maxInt32 when unset.
+//
+//   - maxSize is the field's schema bound; a non-positive value means "no
+//     schema bound".
+//   - InputLen(), when available, is the number of bytes still readable. A
+//     remaining length of 0 is a real bound that rejects any non-zero declared
+//     length; it must not be conflated with "no limit". A negative value (a
+//     defensive guard against a miscounting reader) is clamped to 0.
+//
+// The schema bound is normalized to maxInt32 before merging so a returned 0 can
+// only ever mean "zero bytes remaining". Callers can therefore compare
+// uint(dataLen) > uint(result) directly, with no further 0-means-unlimited
+// special-casing.
 func (d *Decoder) mergeInputLenAndMaxSize(maxSize int) int {
-	if left, ok := d.InputLen(); ok {
-		if maxSize == 0 || left < maxSize {
-			return left
-		}
+	if maxSize <= 0 {
+		maxSize = maxInt32
+	}
+	if left, ok := d.InputLen(); ok && left < maxSize {
+		return max(0, left)
 	}
 	return maxSize
 }

--- a/xdr3/decode_limits_test.go
+++ b/xdr3/decode_limits_test.go
@@ -140,6 +140,82 @@ func TestMaxInputLenDecodeStringBypass(t *testing.T) {
 	}
 }
 
+// TestMaxInputLenPrefixAtEndOfInput is the regression for the length-prefix-at-
+// end-of-input bypass: when a variable-length field's 4-byte length prefix is
+// the final 4 bytes of the input, InputLen() reports 0 bytes remaining. That 0
+// is a genuine bound (reject any non-zero declared length) and must not be
+// mistaken for "no limit configured". The rejection must therefore come from the
+// DecodeString bound check, before DecodeFixedOpaque runs make([]byte, dataLen).
+func TestMaxInputLenPrefixAtEndOfInput(t *testing.T) {
+	cases := []struct {
+		name     string
+		declared uint32
+	}{
+		{"huge declared length (2 GiB allocation averted)", 0x7fffffff},
+		{"small declared length still rejected", 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// [int][string length prefix]; the prefix is the last 4 bytes.
+			payload := make([]byte, 8)
+			binary.BigEndian.PutUint32(payload[0:4], 0x42)
+			binary.BigEndian.PutUint32(payload[4:8], tc.declared)
+
+			// MaxInputLen spans the whole input, so no bytes remain once the
+			// prefix is read — the shape SafeUnmarshalBase64 produces for an
+			// exact buffer.
+			dec := NewDecoderWithOptions(bytes.NewReader(payload),
+				DecodeOptions{MaxInputLen: len(payload)})
+
+			if _, _, err := dec.DecodeInt(); err != nil {
+				t.Fatalf("DecodeInt: %v", err)
+			}
+
+			_, _, err := dec.DecodeString(0)
+			if err == nil {
+				t.Fatal("DecodeString: expected rejection, got nil")
+			}
+
+			var ue *UnmarshalError
+			if !errors.As(err, &ue) {
+				t.Fatalf("DecodeString: error %v is not an *UnmarshalError", err)
+			}
+			// Func must be DecodeString (the bound check), not
+			// DecodeFixedOpaqueInplace (which only fails after the allocation).
+			if ue.Func != "DecodeString" || ue.ErrorCode != ErrOverflow {
+				t.Errorf("rejected by xdr:%s (%v); want DecodeString/ErrOverflow — "+
+					"bound deleted and allocation reached", ue.Func, ue.ErrorCode)
+			}
+		})
+	}
+}
+
+// TestMaxInputLenSlicePrefixAtEndOfInput covers the same bypass through the
+// non-opaque slice path (decodeArray). A []uint32 whose length prefix is the
+// whole input declares a large element count with no element data following;
+// the fix must reject at the decodeArray bound check, before reflect.MakeSlice
+// and the element-decode loop are reached.
+func TestMaxInputLenSlicePrefixAtEndOfInput(t *testing.T) {
+	payload := make([]byte, 4)
+	binary.BigEndian.PutUint32(payload[0:4], 0x7fffffff)
+
+	var out []uint32
+	_, err := UnmarshalWithOptions(bytes.NewReader(payload), &out,
+		DecodeOptions{MaxInputLen: len(payload)})
+	if err == nil {
+		t.Fatal("expected rejection, got nil")
+	}
+
+	var ue *UnmarshalError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error %v is not an *UnmarshalError", err)
+	}
+	if ue.Func != "decodeArray" || ue.ErrorCode != ErrOverflow {
+		t.Errorf("rejected by xdr:%s (%v); want decodeArray/ErrOverflow — "+
+			"bound deleted and allocation reached", ue.Func, ue.ErrorCode)
+	}
+}
+
 // TestMaxInputLenBudget verifies that the wrapper's budget is the minimum of
 // MaxInputLen and the inner reader's reported remaining length, regardless of
 // which is tighter. InputLen() reports the actual initial budget.
@@ -162,5 +238,38 @@ func TestMaxInputLenBudget(t *testing.T) {
 				t.Errorf("InputLen=(%d,%v), want (%d,true)", left, ok, tc.wantBudget)
 			}
 		})
+	}
+}
+
+// negLenReader implements lenLeft but reports a negative remaining length,
+// decoupled from the bytes it actually holds. With MaxInputLen unset the
+// decoder trusts this Len() directly (d.l = r), so it drives InputLen()
+// negative — the input shape decodeMap's clamp must tolerate.
+type negLenReader struct{ r *bytes.Reader }
+
+func (n *negLenReader) Read(p []byte) (int, error) { return n.r.Read(p) }
+func (n *negLenReader) Len() int                   { return -1 }
+
+// TestDecodeMapNegativeInputLenClamped verifies decodeMap's guard clamps a
+// negative InputLen to 0 rather than letting uint(negative) wrap to a huge
+// value and bypass the check. The map length prefix declares one entry with no
+// entry data following; the guard must reject before the decode loop runs.
+func TestDecodeMapNegativeInputLenClamped(t *testing.T) {
+	payload := []byte{0x00, 0x00, 0x00, 0x01} // map length = 1, then nothing
+
+	var m map[uint32]uint32
+	_, err := UnmarshalWithOptions(&negLenReader{r: bytes.NewReader(payload)}, &m,
+		DecodeOptions{})
+	if err == nil {
+		t.Fatal("expected rejection, got nil")
+	}
+
+	var ue *UnmarshalError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error %v is not an *UnmarshalError", err)
+	}
+	if ue.Func != "decodeMap" || ue.ErrorCode != ErrOverflow {
+		t.Errorf("rejected by xdr:%s (%v); want decodeMap/ErrOverflow — "+
+			"negative InputLen wrapped and bypassed the guard", ue.Func, ue.ErrorCode)
 	}
 }

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -323,7 +323,7 @@ func TestUnmarshal(t *testing.T) {
 		// larger than allowed, and len larger than available bytes.
 		{[]byte{0x00, 0x00, 0xFF}, "", 3, &UnmarshalError{ErrorCode: ErrIO}},
 		{[]byte{0xFF, 0xFF, 0xFF, 0xFF}, "", 4, &UnmarshalError{ErrorCode: ErrOverflow}},
-		{[]byte{0x00, 0x00, 0x00, 0xFF}, "", 4, &UnmarshalError{ErrorCode: ErrIO}},
+		{[]byte{0x00, 0x00, 0x00, 0xFF}, "", 4, &UnmarshalError{ErrorCode: ErrOverflow}},
 
 		// []byte - XDR Variable Opaque
 		{[]byte{0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00}, []byte{0x01}, 8, nil},
@@ -332,7 +332,7 @@ func TestUnmarshal(t *testing.T) {
 		// larger than allowed, and data larger than available bytes.
 		{[]byte{0x00, 0x00, 0xFF}, []byte{}, 3, &UnmarshalError{ErrorCode: ErrIO}},
 		{[]byte{0xFF, 0xFF, 0xFF, 0xFF}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrOverflow}},
-		{[]byte{0x00, 0x00, 0x00, 0xFF}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrIO}},
+		{[]byte{0x00, 0x00, 0x00, 0xFF}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrOverflow}},
 
 		// [#]byte - XDR Fixed Opaque
 		{[]byte{0x01, 0x00, 0x00, 0x00}, [1]byte{0x01}, 4, nil},
@@ -642,7 +642,7 @@ func TestDecoder(t *testing.T) {
 		{fDecodeOpaque, []byte{0x00, 0x00, 0xFF}, []byte{}, 3, &UnmarshalError{ErrorCode: ErrIO}},
 		{fDecodeOpaque, []byte{0xFF, 0xFF, 0xFF, 0xFF}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrOverflow}},
 		{fDecodeOpaque, []byte{0x7F, 0xFF, 0xFF, 0xFD}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrOverflow}},
-		{fDecodeOpaque, []byte{0x00, 0x00, 0x00, 0xFF}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrIO}},
+		{fDecodeOpaque, []byte{0x00, 0x00, 0x00, 0xFF}, []byte{}, 4, &UnmarshalError{ErrorCode: ErrOverflow}},
 
 		// String
 		{fDecodeString, []byte{0x00, 0x00, 0x00, 0x00}, "", 4, nil},
@@ -652,7 +652,7 @@ func TestDecoder(t *testing.T) {
 		// larger than allowed, and len larger than available bytes.
 		{fDecodeString, []byte{0x00, 0x00, 0xFF}, "", 3, &UnmarshalError{ErrorCode: ErrIO}},
 		{fDecodeString, []byte{0xFF, 0xFF, 0xFF, 0xFF}, "", 4, &UnmarshalError{ErrorCode: ErrOverflow}},
-		{fDecodeString, []byte{0x00, 0x00, 0x00, 0xFF}, "", 4, &UnmarshalError{ErrorCode: ErrIO}},
+		{fDecodeString, []byte{0x00, 0x00, 0x00, 0xFF}, "", 4, &UnmarshalError{ErrorCode: ErrOverflow}},
 
 		// Uhyper
 		{fDecodeUhyper, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, uint64(0), 8, nil},


### PR DESCRIPTION
## Summary

`mergeInputLenAndMaxSize` overloads the value `0` to mean two different things — "zero input bytes remaining" and "no size limit configured" — and the second meaning wins. When a variable-length field's 4-byte length prefix is the final bytes of the input, `InputLen()` returns `0`, the merge returns `0`, and `DecodeString` / `DecodeOpaque` / `decodeArray` remap that `0` to `maxInt32` via `if maxSize == 0 { maxSize = maxInt32 }`. Both the schema bound and the input-length bound are dropped, so a declared length up to `maxInt32` passes the `uint(dataLen) > uint(maxSize)` check and reaches `make([]byte, dataLen)` in `DecodeFixedOpaque` **before any payload is read** — an oversized allocation driven entirely by an untrusted length prefix.

This is independent of the `MaxInputLen` reader-boundary work in #31 and the depth changes in #32; the reader-level guard is intact, but the consumer-level bound check deletes itself for this input shape.

## Fix

Normalize the schema bound to `maxInt32` **inside** `mergeInputLenAndMaxSize`, before merging with the remaining input length. A returned `0` can then only mean "zero bytes remaining", so the three call sites drop their now-redundant `if maxSize == 0 { maxSize = maxInt32 }` blocks and compare against the merged bound directly.

```go
func (d *Decoder) mergeInputLenAndMaxSize(maxSize int) int {
	if maxSize <= 0 {
		maxSize = maxInt32
	}
	if left, ok := d.InputLen(); ok && left < maxSize {
		return max(0, left)
	}
	return maxSize
}
```

The returned value is now always in `[0, maxInt32]`, so `uint(dataLen) > uint(maxSize)` can never test against a wrapped-negative bound.

**Defense in depth:** `max(0, left)` also clamps a negative `InputLen()` (a miscounting `lenLeft` reader) instead of wrapping to a huge `uint`. The same clamp is added to `decodeMap`'s separate guard so the two length checks can't drift apart.

## Tests

New regressions in `decode_limits_test.go`, each verified to fail before this change and pass after (before the fix they are rejected only later, in `DecodeFixedOpaqueInplace`/`DecodeUint`, i.e. after the allocation/loop is reached):

- `TestMaxInputLenPrefixAtEndOfInput` — `DecodeString`, huge and small declared lengths.
- `TestMaxInputLenSlicePrefixAtEndOfInput` — the non-opaque `decodeArray` path.
- `TestDecodeMapNegativeInputLenClamped` — `decodeMap` with an adversarial negative-`Len()` reader.

Four existing `DecodeString`/`DecodeOpaque` table rows change from `ErrIO` to `ErrOverflow`: these are the cases the table already labels *"len larger than available bytes"*, which is now correctly rejected at the bound check rather than surfacing as an I/O error after the allocation.

## Verification

- `go test -race ./xdr3/` passes; `go vet` and `gofmt` clean.
- Built and tested against downstream `stellar/go-stellar-sdk` (`xdr`, `txnbuild`, `ingest`) via a temporary `replace` — all pass, no behavioral regressions.
